### PR TITLE
Improved vectors and points and added triangles and 2D arrays

### DIFF
--- a/src/io/terminal.h
+++ b/src/io/terminal.h
@@ -100,9 +100,7 @@ namespace Pine::Terminal
 
     void moveCursor(MoveCursorDirection direction, int amount);
 
-    void moveCursor(Vector2D<int> amount);
-
-    inline void moveCursor(int xAmount, int yAmount);
+    void moveCursor(int xAmount, int yAmount);
 
     void setCursorPosition(Point2D<int> position);
 
@@ -147,12 +145,6 @@ namespace Pine::Terminal
     inline void setColor(Color24Bit foregroundColor, Color24Bit backgroundColor) {
         setForegroundColor(foregroundColor);
         setBackgroundColor(backgroundColor);
-    }
-
-
-
-    inline void moveCursor(int xAmount, int yAmount) {
-        moveCursor({ xAmount, yAmount });
     }
 
 

--- a/src/io/terminal_linux.cpp
+++ b/src/io/terminal_linux.cpp
@@ -365,29 +365,29 @@ namespace Pine::Terminal
 
 
 
-    void moveCursor(Vector2D<int> amount)
+    void moveCursor(int xAmount, int yAmount)
     {
         MoveCursorDirection directon;
 
-        if (amount.x > 0)
+        if (xAmount > 0)
             directon = MoveCursorDirection::Right;
         else
         {
             directon = MoveCursorDirection::Left;
-            amount.x *= -1;
+            xAmount *= -1;
         }
 
-        moveCursor(directon, amount.x);
+        moveCursor(directon, xAmount);
 
-        if (amount.y > 0)
+        if (yAmount > 0)
             directon = MoveCursorDirection::Up;
         else
         {
             directon = MoveCursorDirection::Down;
-            amount.y *= -1;
+            yAmount *= -1;
         }
 
-        moveCursor(directon, amount.y);
+        moveCursor(directon, yAmount);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,15 +15,21 @@ int main()
 
     Pine::Size2D<int> terminalSize = Pine::Terminal::size();
     const Pine::Array2D<Pine::Color8Bit> outputBuffer(terminalSize.width, terminalSize.height, 35);
-    
-    for (std::size_t y = 0; y < outputBuffer.size().height; y++)
+
+    outputBuffer.foreach([&](Pine::Color8Bit color)
     {
-        for (std::size_t x = 0; x < outputBuffer.size().width; x++)
-        {
-            Pine::Terminal::setBackgroundColor(outputBuffer.at(x, y));
-            Pine::Terminal::write(' ');
-        }
-    }
+        Pine::Terminal::setBackgroundColor(color);
+        Pine::Terminal::write(' ');
+    });
+    
+    // for (std::size_t y = 0; y < outputBuffer.size().height; y++)
+    // {
+    //     for (std::size_t x = 0; x < outputBuffer.size().width; x++)
+    //     {
+    //         Pine::Terminal::setBackgroundColor(outputBuffer.at(x, y));
+    //         Pine::Terminal::write(' ');
+    //     }
+    // }
 
     Pine::Terminal::flush();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,42 @@
 
 
 
+void printVectorData(std::string name, Pine::Vector2D v);
+
+
+
 int main()
 {
     Pine::Terminal::setBufferSize(1024);
 
+    Pine::Vector2D v;
+    v.x = 1;
+    v.y = 1;
+
+    printVectorData("v", v);
+
+    Pine::Vector2D u;
+    u.x = 1;
+    u.y = 1;
+
+    printVectorData("u", u);
+
+    Pine::Vector2D w = v + u;
+    
+    printVectorData("w", w);
+
+    w *= -5;
+
+    printVectorData("w", w);
+
+    Pine::Terminal::flush();
+
     return 0;
+}
+
+
+
+void printVectorData(std::string name, Pine::Vector2D v)
+{
+    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ')');
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,24 +13,23 @@ int main()
     Pine::Terminal::setBufferSize(1024);
 
     Pine::Vector2D v;
-    v.x = 0;
+    v.x = 1;
     v.y = 1;
-
     printVectorData("v", v);
 
     Pine::Vector2D u;
     u.x = 0;
     u.y = -2;
-
     printVectorData("u", u);
 
     Pine::Vector2D w = v + u;
-    
-    printVectorData("v + u", w);
+    printVectorData("w = v + u", w);
 
     w *= -5;
+    printVectorData("w * -5", w);
 
-    printVectorData("(v + u) * -5", w);
+    w = Pine::normalize(w);
+    printVectorData("w norm", w);
 
     Pine::Terminal::flush();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,40 +13,17 @@ int main()
 {
     Pine::Terminal::setBufferSize(1024);
 
-    Pine::Vector3D a;
-    a.x = 1;
-    a.y = 2;
-    a.z = 3;
-    printVectorData("a", a);
+    Pine::Size2D<int> terminalSize = Pine::Terminal::size();
+    const Pine::Array2D<Pine::Color8Bit> outputBuffer(terminalSize.width, terminalSize.height, 35);
     
-    Pine::Vector3D b;
-    b.x = 4;
-    b.y = 5;
-    b.z = 6;
-    printVectorData("b", b);
-
-    Pine::Vector3D abCross = Pine::cross(a, b);
-    printVectorData("a x b", abCross);
-    printVectorData("norm(a x b)", Pine::normalize(abCross));
-
-    // Pine::Vector2D v;
-    // v.x = 1;
-    // v.y = 1;
-    // printVectorData("v", v);
-
-    // Pine::Vector2D u;
-    // u.x = 0;
-    // u.y = -2;
-    // printVectorData("u", u);
-
-    // Pine::Vector2D w = v + u;
-    // printVectorData("w = v + u", w);
-
-    // w *= -5;
-    // printVectorData("w * -5", w);
-
-    // w = Pine::normalize(w);
-    // printVectorData("w norm", w);
+    for (std::size_t y = 0; y < outputBuffer.size().height; y++)
+    {
+        for (std::size_t x = 0; x < outputBuffer.size().width; x++)
+        {
+            Pine::Terminal::setBackgroundColor(outputBuffer.at(x, y));
+            Pine::Terminal::write(' ');
+        }
+    }
 
     Pine::Terminal::flush();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 
 
 void printVectorData(std::string name, Pine::Vector2D v);
+void printVectorData(std::string name, Pine::Vector3D v);
 
 
 
@@ -12,24 +13,40 @@ int main()
 {
     Pine::Terminal::setBufferSize(1024);
 
-    Pine::Vector2D v;
-    v.x = 1;
-    v.y = 1;
-    printVectorData("v", v);
+    Pine::Vector3D a;
+    a.x = 1;
+    a.y = 2;
+    a.z = 3;
+    printVectorData("a", a);
+    
+    Pine::Vector3D b;
+    b.x = 4;
+    b.y = 5;
+    b.z = 6;
+    printVectorData("b", b);
 
-    Pine::Vector2D u;
-    u.x = 0;
-    u.y = -2;
-    printVectorData("u", u);
+    Pine::Vector3D abCross = Pine::cross(a, b);
+    printVectorData("a x b", abCross);
+    printVectorData("norm(a x b)", Pine::normalize(abCross));
 
-    Pine::Vector2D w = v + u;
-    printVectorData("w = v + u", w);
+    // Pine::Vector2D v;
+    // v.x = 1;
+    // v.y = 1;
+    // printVectorData("v", v);
 
-    w *= -5;
-    printVectorData("w * -5", w);
+    // Pine::Vector2D u;
+    // u.x = 0;
+    // u.y = -2;
+    // printVectorData("u", u);
 
-    w = Pine::normalize(w);
-    printVectorData("w norm", w);
+    // Pine::Vector2D w = v + u;
+    // printVectorData("w = v + u", w);
+
+    // w *= -5;
+    // printVectorData("w * -5", w);
+
+    // w = Pine::normalize(w);
+    // printVectorData("w norm", w);
 
     Pine::Terminal::flush();
 
@@ -41,4 +58,9 @@ int main()
 void printVectorData(std::string name, Pine::Vector2D v)
 {
     Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ") length: " + std::to_string(v.length()));
+}
+
+void printVectorData(std::string name, Pine::Vector3D v)
+{
+    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + ") length: " + std::to_string(v.length()));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,24 +13,24 @@ int main()
     Pine::Terminal::setBufferSize(1024);
 
     Pine::Vector2D v;
-    v.x = 1;
+    v.x = 0;
     v.y = 1;
 
     printVectorData("v", v);
 
     Pine::Vector2D u;
-    u.x = 1;
-    u.y = 1;
+    u.x = 0;
+    u.y = -2;
 
     printVectorData("u", u);
 
     Pine::Vector2D w = v + u;
     
-    printVectorData("w", w);
+    printVectorData("v + u", w);
 
     w *= -5;
 
-    printVectorData("w", w);
+    printVectorData("(v + u) * -5", w);
 
     Pine::Terminal::flush();
 
@@ -41,5 +41,5 @@ int main()
 
 void printVectorData(std::string name, Pine::Vector2D v)
 {
-    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ')');
+    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ") length: " + std::to_string(v.length()));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,14 +13,20 @@ int main()
 {
     Pine::Terminal::setBufferSize(1024);
 
-    Pine::Size2D<int> terminalSize = Pine::Terminal::size();
-    const Pine::Array2D<Pine::Color8Bit> outputBuffer(terminalSize.width, terminalSize.height, 35);
+    Pine::Vector2D v(1, 1);
+    Pine::Terminal::writeLine('(' + std::to_string(v.x) + ", " + std::to_string(v.y) + ") " + std::to_string(v.length()));
 
-    outputBuffer.foreach([&](Pine::Color8Bit color)
-    {
-        Pine::Terminal::setBackgroundColor(color);
-        Pine::Terminal::write(' ');
-    });
+    v = Pine::normalize(v);
+    Pine::Terminal::writeLine('(' + std::to_string(v.x) + ", " + std::to_string(v.y) + ") " + std::to_string(v.length()));
+
+    // Pine::Size2D<int> terminalSize = Pine::Terminal::size();
+    // const Pine::Array2D<Pine::Color8Bit> outputBuffer(terminalSize.width, terminalSize.height, 35);
+
+    // outputBuffer.foreach([&](Pine::Color8Bit color)
+    // {
+    //     Pine::Terminal::setBackgroundColor(color);
+    //     Pine::Terminal::write(' ');
+    // });
     
     // for (std::size_t y = 0; y < outputBuffer.size().height; y++)
     // {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,33 +8,5 @@ int main()
 {
     Pine::Terminal::setBufferSize(1024);
 
-    std::string test = Pine::Terminal::readLine();
-    Pine::Terminal::writeLine(test);
-
-
-
-    // Pine::Terminal::setBufferSize(1024);
-    // Pine::Terminal::writeLine("test");
-
-    // for (std::size_t i = 0; i < 990000; i++)
-    // {
-    //     Pine::Terminal::setBackgroundColor((i % 256));
-    //     Pine::Terminal::write(' ');
-    //     Pine::Terminal::flush();
-    // }
-
-    // Pine::Terminal::resetBackgroundColor();
-
-    // std::string test = Pine::Terminal::readLine();
-    // Pine::Terminal::writeLine(test);
-    // Pine::Terminal::write(Pine::Terminal::readLine());
-
-
-
-    // while (Pine::Terminal::readChar() != 'q')
-    // {
-    //     Pine::Terminal::writeLine("hewwo");
-    // }
-
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,55 +1,23 @@
 #include "io/terminal.h"
+#include "math.h"
 
 #include <string>
-
-
-
-void printVectorData(std::string name, Pine::Vector2D v);
-void printVectorData(std::string name, Pine::Vector3D v);
 
 
 
 int main()
 {
     Pine::Terminal::setBufferSize(1024);
-
-    Pine::Vector2D v(1, 1);
-    Pine::Terminal::writeLine('(' + std::to_string(v.x) + ", " + std::to_string(v.y) + ") " + std::to_string(v.length()));
-
-    v = Pine::normalize(v);
-    Pine::Terminal::writeLine('(' + std::to_string(v.x) + ", " + std::to_string(v.y) + ") " + std::to_string(v.length()));
-
-    // Pine::Size2D<int> terminalSize = Pine::Terminal::size();
-    // const Pine::Array2D<Pine::Color8Bit> outputBuffer(terminalSize.width, terminalSize.height, 35);
-
-    // outputBuffer.foreach([&](Pine::Color8Bit color)
-    // {
-    //     Pine::Terminal::setBackgroundColor(color);
-    //     Pine::Terminal::write(' ');
-    // });
     
-    // for (std::size_t y = 0; y < outputBuffer.size().height; y++)
-    // {
-    //     for (std::size_t x = 0; x < outputBuffer.size().width; x++)
-    //     {
-    //         Pine::Terminal::setBackgroundColor(outputBuffer.at(x, y));
-    //         Pine::Terminal::write(' ');
-    //     }
-    // }
+    Pine::Point2D<int> p1(3, 2);
+    Pine::Point2D<int> p2(1, 5);
+
+    Pine::Vector2D v = p2 - p1;
+
+    Pine::Terminal::writeLine("distance: " + std::to_string(Pine::distance(p1, p2)));
+    Pine::Terminal::writeLine("v length: " + std::to_string(v.length()));
 
     Pine::Terminal::flush();
 
     return 0;
-}
-
-
-
-void printVectorData(std::string name, Pine::Vector2D v)
-{
-    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ") length: " + std::to_string(v.length()));
-}
-
-void printVectorData(std::string name, Pine::Vector3D v)
-{
-    Pine::Terminal::writeLine(name + " values: (" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + ") length: " + std::to_string(v.length()));
 }

--- a/src/math.h
+++ b/src/math.h
@@ -1,6 +1,7 @@
 #ifndef PINE_MATH_H
 #define PINE_MATH_H
 
+#include "math/array.h"
 #include "math/point.h"
 #include "math/size.h"
 #include "math/vector.h"

--- a/src/math.h
+++ b/src/math.h
@@ -4,6 +4,7 @@
 #include "math/array.h"
 #include "math/point.h"
 #include "math/size.h"
+#include "math/triangle.h"
 #include "math/vector.h"
 
 #endif // PINE_MATH_H

--- a/src/math/array.h
+++ b/src/math/array.h
@@ -45,6 +45,19 @@ namespace Pine
         inline void resize(std::size_t width, std::size_t height, const T& value);
         inline void clear();
 
+        template <typename F>
+        void foreach(F func);
+        template <typename F>
+        void foreach(F func) const;
+        template <typename F>
+        void foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func);
+        template <typename F>
+        void foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func) const;
+        template <typename F>
+        inline void foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func);
+        template <typename F>
+        inline void foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) const;
+
     private:
 
         std::vector<T>      m_data;
@@ -167,6 +180,54 @@ namespace Pine
     {
         m_size = { 0, 0 };
         m_data.clear();
+    }
+
+
+
+    template <typename T>
+    template <typename F>
+    void Array2D<T>::foreach(F func)
+    {
+        for (std::size_t i = 0; i < m_data.size(); i++)
+            func(m_data.at(i));
+    }
+
+    template <typename T>
+    template <typename F>
+    void Array2D<T>::foreach(F func) const
+    {
+        for (std::size_t i = 0; i < m_data.size(); i++)
+            func(m_data.at(i));
+    }
+
+    template <typename T>
+    template <typename F>
+    void Array2D<T>::foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func)
+    {
+        for (std::size_t y = start.y; y < size.height; y++)
+            for (std::size_t x = start.x; x < size.width; x++)
+                func(m_data.at(index(x, y, this->size())));
+    }
+
+    template <typename T>
+    template <typename F>
+    void Array2D<T>::foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func) const
+    {
+        for (std::size_t y = start.y; y < size.height; y++)
+            for (std::size_t x = start.x; x < size.width; x++)
+                func(m_data.at(index(x, y, this->size())));
+    }
+
+    template <typename T>
+    template <typename F>
+    inline void Array2D<T>::foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) {
+        foreach({ x, y }, { width, height }, func);
+    }
+
+    template <typename T>
+    template <typename F>
+    inline void Array2D<T>::foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) const {
+        foreach({ x, y }, { width, height }, func);
     }
 
 

--- a/src/math/array.h
+++ b/src/math/array.h
@@ -1,0 +1,233 @@
+#ifndef PINE_MATH_ARRAY_H
+#define PINE_MATH_ARRAY_H
+
+#include "point.h"
+#include "size.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+
+
+namespace Pine
+{
+    template <typename T>
+    class Array2D;
+
+
+
+    template <typename T>
+    class Array2D
+    {
+    public:
+
+        inline Array2D();
+        inline Array2D(Size2D<std::size_t> initSize);
+        inline Array2D(Size2D<std::size_t> initSize, const T& value);
+        inline Array2D(std::size_t width, std::size_t height);
+        inline Array2D(std::size_t width, std::size_t height, const T& value);
+
+        inline bool empty() const;
+        inline Size2D<std::size_t> size() const;
+        inline bool inBounds(Point2D<std::size_t> pos) const;
+        inline bool inBounds(std::size_t x, std::size_t y) const;
+
+        inline T& at(Point2D<std::size_t> pos);
+        inline const T& at(Point2D<std::size_t> pos) const;
+        inline T& at(std::size_t x, std::size_t y);
+        inline const T& at(std::size_t x, std::size_t y) const;
+
+        inline void resize(Size2D<std::size_t> newSize);
+        inline void resize(Size2D<std::size_t> newSize, const T& value);
+        inline void resize(std::size_t width, std::size_t height);
+        inline void resize(std::size_t width, std::size_t height, const T& value);
+        inline void clear();
+
+    private:
+
+        std::vector<T>      m_data;
+        Size2D<std::size_t> m_size;
+
+
+        static inline std::size_t index(Point2D<std::size_t> pos, std::size_t width);
+        static inline std::size_t index(Point2D<std::size_t> pos, Size2D<std::size_t> size);
+        static inline std::size_t index(std::size_t x, std::size_t y, std::size_t width);
+        static inline std::size_t index(std::size_t x, std::size_t y, Size2D<std::size_t> size);
+
+        void resizeData(Size2D<std::size_t> newSize);
+        void resizeData(Size2D<std::size_t> newSize, const T& value);
+        void replaceDataWithNewData(std::vector<T>& newData, Size2D<std::size_t> newSize);
+    };
+
+
+
+    template <typename T>
+    inline Array2D<T>::Array2D() : Array2D(0, 0) {}
+    
+    template <typename T>
+    inline Array2D<T>::Array2D(Size2D<std::size_t> initSize) :
+        m_data(initSize.width * initSize.height), m_size(initSize) {}
+    
+    template <typename T>
+    inline Array2D<T>::Array2D(Size2D<std::size_t> initSize, const T& value) :
+        m_data(initSize.width * initSize.height, value), m_size(initSize) {}
+    
+    template <typename T>
+    inline Array2D<T>::Array2D(std::size_t width, std::size_t height) :
+        Array2D(Size2D<std::size_t>{ width, height }) {}
+    
+    template <typename T>
+    inline Array2D<T>::Array2D(std::size_t width, std::size_t height, const T& value) :
+        Array2D(Size2D<std::size_t>{ width, height }, value) {}
+        
+
+
+    template <typename T>
+    inline bool Array2D<T>::empty() const {
+        return size().width == 0; // Width and height should both be 0 if array is empty
+    }
+
+
+
+    template <typename T>
+    inline Size2D<std::size_t> Array2D<T>::size() const {
+        return m_size;
+    }
+
+
+
+    template <typename T>
+    inline bool Array2D<T>::inBounds(Point2D<std::size_t> pos) const {
+        return (pos.x < size().width && pos.y < size().height);
+    }
+
+    template <typename T>
+    inline bool Array2D<T>::inBounds(std::size_t x, std::size_t y) const {
+        return inBounds({ x, y });
+    }
+
+
+
+    template <typename T>
+    inline T& Array2D<T>::at(Point2D<std::size_t> pos)
+    {
+        if (inBounds(pos))
+            return m_data.at(index(pos, size()));
+        else
+            throw std::out_of_range("Position was outside the 2D array");
+    }
+
+    template <typename T>
+    inline const T& Array2D<T>::at(Point2D<std::size_t> pos) const
+    {
+        if (inBounds(pos))
+            return m_data.at(index(pos, size()));
+        else
+            throw std::out_of_range("Position was outside the 2D array");
+    }
+
+    template <typename T>
+    inline T& Array2D<T>::at(std::size_t x, std::size_t y) {
+        return at({ x, y });
+    }
+
+    template <typename T>
+    inline const T& Array2D<T>::at(std::size_t x, std::size_t y) const {
+        return at({ x, y });
+    }
+
+
+
+    template <typename T>
+    inline void Array2D<T>::resize(Size2D<std::size_t> newSize) {
+        resizeData(newSize);
+    }
+
+    template <typename T>
+    inline void Array2D<T>::resize(Size2D<std::size_t> newSize, const T& value) {
+        resizeData(newSize, value);
+    }
+
+    template <typename T>
+    inline void Array2D<T>::resize(std::size_t width, std::size_t height) {
+        resize({ width, height });
+    }
+
+    template <typename T>
+    inline void Array2D<T>::resize(std::size_t width, std::size_t height, const T& value) {
+        resize({ width, height }, value);
+    }
+
+
+
+    template <typename T>
+    inline void Array2D<T>::clear()
+    {
+        m_size = { 0, 0 };
+        m_data.clear();
+    }
+
+
+    
+    template <typename T>
+    inline std::size_t Array2D<T>::index(Point2D<std::size_t> pos, std::size_t width) {
+        return pos.x + (pos.y * width);
+    }
+
+    template <typename T>
+    inline std::size_t Array2D<T>::index(Point2D<std::size_t> pos, Size2D<std::size_t> size) {
+        return index(pos, size.width);
+    }
+
+    template <typename T>
+    inline std::size_t Array2D<T>::index(std::size_t x, std::size_t y, std::size_t width) {
+        return index({ x , y }, width);
+    }
+
+    template <typename T>
+    inline std::size_t Array2D<T>::index(std::size_t x, std::size_t y, Size2D<std::size_t> size) {
+        return index({ x, y }, size);
+    }
+
+
+
+    template <typename T>
+    void Array2D<T>::resizeData(Size2D<std::size_t> newSize)
+    {
+        if (newSize == size())
+            return;
+        
+        std::vector<T> newData(newSize.width * newSize.height);
+        replaceDataWithNewData(newData, newSize);
+    }
+
+    template <typename T>
+    void Array2D<T>::resizeData(Size2D<std::size_t> newSize, const T& value)
+    {
+        if (newSize == size())
+            return;
+
+        std::vector<T> newData(newSize.width * newSize.height, value);
+        replaceDataWithNewData(newData, newSize);
+    }
+
+
+
+    template <typename T>
+    void Array2D<T>::replaceDataWithNewData(std::vector<T>& newData, Size2D<std::size_t> newSize)
+    {
+        Size2D<std::size_t> bounds;
+        bounds.width = std::min(size().width, newSize.width);
+        bounds.height = std::min(size().height, newSize.height);
+
+        for (std::size_t y = 0; y < bounds.height; y++)
+            for (std::size_t x = 0; x < bounds.width; x++)
+                newData.at(index(x, y, newSize)) = m_data.at(index(x, y, size()));
+
+        m_data = newData;
+    }
+}
+
+#endif // PINE_MATH_ARRAY_H

--- a/src/math/array.h
+++ b/src/math/array.h
@@ -49,14 +49,6 @@ namespace Pine
         void foreach(F func);
         template <typename F>
         void foreach(F func) const;
-        template <typename F>
-        void foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func);
-        template <typename F>
-        void foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func) const;
-        template <typename F>
-        inline void foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func);
-        template <typename F>
-        inline void foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) const;
 
     private:
 
@@ -198,36 +190,6 @@ namespace Pine
     {
         for (std::size_t i = 0; i < m_data.size(); i++)
             func(m_data.at(i));
-    }
-
-    template <typename T>
-    template <typename F>
-    void Array2D<T>::foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func)
-    {
-        for (std::size_t y = start.y; y < size.height; y++)
-            for (std::size_t x = start.x; x < size.width; x++)
-                func(m_data.at(index(x, y, this->size())));
-    }
-
-    template <typename T>
-    template <typename F>
-    void Array2D<T>::foreach(Point2D<std::size_t> start, Size2D<std::size_t> size, F func) const
-    {
-        for (std::size_t y = start.y; y < size.height; y++)
-            for (std::size_t x = start.x; x < size.width; x++)
-                func(m_data.at(index(x, y, this->size())));
-    }
-
-    template <typename T>
-    template <typename F>
-    inline void Array2D<T>::foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) {
-        foreach({ x, y }, { width, height }, func);
-    }
-
-    template <typename T>
-    template <typename F>
-    inline void Array2D<T>::foreach(std::size_t x, std::size_t y, std::size_t width, std::size_t height, F func) const {
-        foreach({ x, y }, { width, height }, func);
     }
 
 

--- a/src/math/math_common.h
+++ b/src/math/math_common.h
@@ -4,7 +4,7 @@
 namespace Pine
 {
     // Clearer intent that using std::pow() or std::exp() and avoids the
-    // headahces of the float requirements of those functions
+    // headaches of the float requirements of those functions
     template <typename T>
     inline T square(const T& val);
 

--- a/src/math/math_common.h
+++ b/src/math/math_common.h
@@ -1,0 +1,19 @@
+#ifndef PINE_MATH_MATH_COMMON_H
+#define PINE_MATH_MATH_COMMON_H
+
+namespace Pine
+{
+    // Clearer intent that using std::pow() or std::exp() and avoids the
+    // headahces of the float requirements of those functions
+    template <typename T>
+    inline T square(const T& val);
+
+
+
+    template <typename T>
+    inline T square(const T& val) {
+        return val * val;
+    }
+}
+
+#endif // PINE_MATH_MATH_COMMON_H

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -91,12 +91,12 @@ namespace Pine
 
     template <typename T>
     float distance(const Point2D<T>& p1, const Point2D<T>& p2) {
-        return std::sqrt(square(p2.x - p1.x) + square(p2.y - p1.y));
+        return std::sqrt(static_cast<float>(square(p2.x - p1.x) + square(p2.y - p1.y)));
     }
 
     template <typename T>
     float distance(const Point3D<T>& p1, const Point3D<T>& p2) {
-        return std::sqrt(square(p2.x - p1.x) + square(p2.y - p1.y) + square(p2.z - p1.z));
+        return std::sqrt(static_cast<float>(square(p2.x - p1.x) + square(p2.y - p1.y) + square(p2.z - p1.z)));
     }
 }
 

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -22,6 +22,19 @@ namespace Pine
 
         inline bool operator==(const Point2D<T>& other) const;
         inline bool operator!=(const Point2D<T>& other) const;
+
+        explicit inline operator Point2D<char>() const { return Point2D<char>(x, y); }
+        explicit inline operator Point2D<unsigned char>() const { return Point2D<unsigned char>(x, y); }
+        explicit inline operator Point2D<short>() const { return Point2D<short>(x, y); }
+        explicit inline operator Point2D<unsigned short>() const { return Point2D<unsigned short>(x, y); }
+        explicit inline operator Point2D<int>() const { return Point2D<int>(x, y); }
+        explicit inline operator Point2D<unsigned int>() const { return Point2D<unsigned int>(x, y); }
+        explicit inline operator Point2D<long>() const { return Point2D<long>(x, y); }
+        explicit inline operator Point2D<unsigned long>() const { return Point2D<unsigned long>(x, y); }
+        explicit inline operator Point2D<long long>() const { return Point2D<long long>(x, y); }
+        explicit inline operator Point2D<unsigned long long>() const { return Point2D<unsigned long long>(x, y); }
+        explicit inline operator Point2D<float>() const { return Point2D<float>(x, y); }
+        explicit inline operator Point2D<double>() const { return Point2D<double>(x, y); }
     };
 
 
@@ -51,6 +64,19 @@ namespace Pine
 
         inline bool operator==(const Point3D<T>& other) const;
         inline bool operator!=(const Point3D<T>& other) const;
+
+        explicit inline operator Point3D<char>() const { return Point3D<char>(x, y, z); }
+        explicit inline operator Point3D<unsigned char>() const { return Point3D<unsigned char>(x, y, z); }
+        explicit inline operator Point3D<short>() const { return Point3D<short>(x, y, z); }
+        explicit inline operator Point3D<unsigned short>() const { return Point3D<unsigned short>(x, y, z); }
+        explicit inline operator Point3D<int>() const { return Point3D<int>(x, y, z); }
+        explicit inline operator Point3D<unsigned int>() const { return Point3D<unsigned int>(x, y, z); }
+        explicit inline operator Point3D<long>() const { return Point3D<long>(x, y, z); }
+        explicit inline operator Point3D<unsigned long>() const { return Point3D<unsigned long>(x, y, z); }
+        explicit inline operator Point3D<long long>() const { return Point3D<long long>(x, y, z); }
+        explicit inline operator Point3D<unsigned long long>() const { return Point3D<unsigned long long>(x, y, z); }
+        explicit inline operator Point3D<float>() const { return Point3D<float>(x, y, z); }
+        explicit inline operator Point3D<double>() const { return Point3D<double>(x, y, z); }
     };
 
 

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -23,18 +23,8 @@ namespace Pine
         inline bool operator==(const Point2D<T>& other) const;
         inline bool operator!=(const Point2D<T>& other) const;
 
-        explicit inline operator Point2D<char>() const { return Point2D<char>(x, y); }
-        explicit inline operator Point2D<unsigned char>() const { return Point2D<unsigned char>(x, y); }
-        explicit inline operator Point2D<short>() const { return Point2D<short>(x, y); }
-        explicit inline operator Point2D<unsigned short>() const { return Point2D<unsigned short>(x, y); }
-        explicit inline operator Point2D<int>() const { return Point2D<int>(x, y); }
-        explicit inline operator Point2D<unsigned int>() const { return Point2D<unsigned int>(x, y); }
-        explicit inline operator Point2D<long>() const { return Point2D<long>(x, y); }
-        explicit inline operator Point2D<unsigned long>() const { return Point2D<unsigned long>(x, y); }
-        explicit inline operator Point2D<long long>() const { return Point2D<long long>(x, y); }
-        explicit inline operator Point2D<unsigned long long>() const { return Point2D<unsigned long long>(x, y); }
-        explicit inline operator Point2D<float>() const { return Point2D<float>(x, y); }
-        explicit inline operator Point2D<double>() const { return Point2D<double>(x, y); }
+        template <typename TReturn>
+        explicit inline operator Point2D<TReturn>() const { return Point2D<TReturn>(static_cast<TReturn>(x), static_cast<TReturn>(y)); }
     };
 
 
@@ -65,18 +55,8 @@ namespace Pine
         inline bool operator==(const Point3D<T>& other) const;
         inline bool operator!=(const Point3D<T>& other) const;
 
-        explicit inline operator Point3D<char>() const { return Point3D<char>(x, y, z); }
-        explicit inline operator Point3D<unsigned char>() const { return Point3D<unsigned char>(x, y, z); }
-        explicit inline operator Point3D<short>() const { return Point3D<short>(x, y, z); }
-        explicit inline operator Point3D<unsigned short>() const { return Point3D<unsigned short>(x, y, z); }
-        explicit inline operator Point3D<int>() const { return Point3D<int>(x, y, z); }
-        explicit inline operator Point3D<unsigned int>() const { return Point3D<unsigned int>(x, y, z); }
-        explicit inline operator Point3D<long>() const { return Point3D<long>(x, y, z); }
-        explicit inline operator Point3D<unsigned long>() const { return Point3D<unsigned long>(x, y, z); }
-        explicit inline operator Point3D<long long>() const { return Point3D<long long>(x, y, z); }
-        explicit inline operator Point3D<unsigned long long>() const { return Point3D<unsigned long long>(x, y, z); }
-        explicit inline operator Point3D<float>() const { return Point3D<float>(x, y, z); }
-        explicit inline operator Point3D<double>() const { return Point3D<double>(x, y, z); }
+        template <typename TReturn>
+        explicit inline operator Point3D<TReturn>() const { return Point3D<TReturn>(static_cast<TReturn>(x), static_cast<TReturn>(y), static_cast<TReturn>(z)); }
     };
 
 

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -12,6 +12,9 @@ namespace Pine
     template <typename T>
     struct Point3D;
 
+    // These are functionally equivalent to getting the length of the vector
+    // from p1 to p2, but these functions defer the float conversion to the end
+    // of the calculation and are more obvious/intuitive
     template <typename T>
     float distance(const Point2D<T>& p1, const Point2D<T>& p2);
     template <typename T>

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -1,6 +1,10 @@
 #ifndef PINE_MATH_POINT_H
 #define PINE_MATH_POINT_H
 
+#include "math_common.h"
+
+#include <cmath>
+
 namespace Pine
 {
     template <typename T>
@@ -8,7 +12,12 @@ namespace Pine
     template <typename T>
     struct Point3D;
 
+    template <typename T>
+    float distance(const Point2D<T>& p1, const Point2D<T>& p2);
+    template <typename T>
+    float distance(const Point3D<T>& p1, const Point3D<T>& p2);
 
+    // vvv Point2D vvv
 
     template <typename T>
     struct Point2D
@@ -23,6 +32,8 @@ namespace Pine
         inline bool operator==(const Point2D<T>& other) const;
         inline bool operator!=(const Point2D<T>& other) const;
 
+        // Using template types so all supported conversions from T to TReturn
+        // can be used instead of only explicity supported conversions
         template <typename TReturn>
         explicit inline operator Point2D<TReturn>() const { return Point2D<TReturn>(static_cast<TReturn>(x), static_cast<TReturn>(y)); }
     };
@@ -39,7 +50,7 @@ namespace Pine
         return !operator==(other);
     }
 
-
+    // vvv Point3D vvv // ^^^ Point2D ^^^
 
     template <typename T>
     struct Point3D
@@ -55,6 +66,8 @@ namespace Pine
         inline bool operator==(const Point3D<T>& other) const;
         inline bool operator!=(const Point3D<T>& other) const;
 
+        // Using template types so all supported conversions from T to TReturn
+        // can be used instead of only explicity supported conversions
         template <typename TReturn>
         explicit inline operator Point3D<TReturn>() const { return Point3D<TReturn>(static_cast<TReturn>(x), static_cast<TReturn>(y), static_cast<TReturn>(z)); }
     };
@@ -69,6 +82,18 @@ namespace Pine
     template <typename T>
     inline bool Point3D<T>::operator!=(const Point3D<T>& other) const {
         return !operator==(other);
+    }
+
+    // vvv Free Functions vvv // ^^^ Point3D ^^^
+
+    template <typename T>
+    float distance(const Point2D<T>& p1, const Point2D<T>& p2) {
+        return std::sqrt(square(p2.x - p1.x) + square(p2.y - p1.y));
+    }
+
+    template <typename T>
+    float distance(const Point3D<T>& p1, const Point3D<T>& p2) {
+        return std::sqrt(square(p2.x - p1.x) + square(p2.y - p1.y) + square(p2.z - p1.z));
     }
 }
 

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -5,7 +5,6 @@ namespace Pine
 {
     template <typename T>
     struct Point2D;
-
     template <typename T>
     struct Point3D;
 

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -16,9 +16,9 @@ namespace Pine
     // from p1 to p2, but these functions defer the float conversion to the end
     // of the calculation and are more obvious/intuitive
     template <typename T>
-    float distance(const Point2D<T>& p1, const Point2D<T>& p2);
+    inline float distance(const Point2D<T>& p1, const Point2D<T>& p2);
     template <typename T>
-    float distance(const Point3D<T>& p1, const Point3D<T>& p2);
+    inline float distance(const Point3D<T>& p1, const Point3D<T>& p2);
 
     // vvv Point2D vvv
 
@@ -90,12 +90,12 @@ namespace Pine
     // vvv Free Functions vvv // ^^^ Point3D ^^^
 
     template <typename T>
-    float distance(const Point2D<T>& p1, const Point2D<T>& p2) {
+    inline float distance(const Point2D<T>& p1, const Point2D<T>& p2) {
         return std::sqrt(static_cast<float>(square(p2.x - p1.x) + square(p2.y - p1.y)));
     }
 
     template <typename T>
-    float distance(const Point3D<T>& p1, const Point3D<T>& p2) {
+    inline float distance(const Point3D<T>& p1, const Point3D<T>& p2) {
         return std::sqrt(static_cast<float>(square(p2.x - p1.x) + square(p2.y - p1.y) + square(p2.z - p1.z)));
     }
 }

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -17,6 +17,10 @@ namespace Pine
         T x;
         T y;
 
+
+        inline Point2D() {}
+        inline Point2D(T x, T y) : x(x), y(y) {}
+
         inline bool operator==(const Point2D<T>& other) const {
             return x == other.x && y == other.y;
         }
@@ -34,6 +38,10 @@ namespace Pine
         T x;
         T y;
         T z;
+
+
+        inline Point3D() {}
+        inline Point3D(T x, T y, T z) : x(x), y(y), z(z) {}
 
         inline bool operator==(const Point3D<T>& other) const {
             return x == other.x && y == other.y && z == other.z;

--- a/src/math/point.h
+++ b/src/math/point.h
@@ -21,14 +21,21 @@ namespace Pine
         inline Point2D() {}
         inline Point2D(T x, T y) : x(x), y(y) {}
 
-        inline bool operator==(const Point2D<T>& other) const {
-            return x == other.x && y == other.y;
-        }
-
-        inline bool operator!=(const Point2D<T>& other) const {
-            return !operator==(other);
-        }
+        inline bool operator==(const Point2D<T>& other) const;
+        inline bool operator!=(const Point2D<T>& other) const;
     };
+
+
+
+    template <typename T>
+    inline bool Point2D<T>::operator==(const Point2D<T>& other) const {
+        return x == other.x && y == other.y;
+    }
+
+    template <typename T>
+    inline bool Point2D<T>::operator!=(const Point2D<T>& other) const {
+        return !operator==(other);
+    }
 
 
 
@@ -43,14 +50,21 @@ namespace Pine
         inline Point3D() {}
         inline Point3D(T x, T y, T z) : x(x), y(y), z(z) {}
 
-        inline bool operator==(const Point3D<T>& other) const {
-            return x == other.x && y == other.y && z == other.z;
-        }
-
-        inline bool operator!=(const Point3D<T>& other) const {
-            return !operator==(other);
-        }
+        inline bool operator==(const Point3D<T>& other) const;
+        inline bool operator!=(const Point3D<T>& other) const;
     };
+
+
+
+    template <typename T>
+    inline bool Point3D<T>::operator==(const Point3D<T>& other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+
+    template <typename T>
+    inline bool Point3D<T>::operator!=(const Point3D<T>& other) const {
+        return !operator==(other);
+    }
 }
 
 #endif // PINE_MATH_POINT_H

--- a/src/math/triangle.h
+++ b/src/math/triangle.h
@@ -1,0 +1,38 @@
+#ifndef PINE_MATH_TRIANGLE_H
+#define PINE_MATH_TRIANGLE_H
+
+#include "point.h"
+
+namespace Pine
+{
+    struct Triangle;
+    
+
+
+    struct Triangle
+    {
+        Point2D<float> a;
+        Point2D<float> b;
+        Point2D<float> c;
+
+
+        inline Triangle() {}
+        inline Triangle(Point2D<float> a, Point2D<float> b, Point2D<float> c) : a(a), b(b), c(c) {}
+        inline Triangle(float aX, float aY, float bX, float bY, float cX, float cY) : a(aX, aY), b(bX, bY), c(cX, cY) {}
+
+        inline bool operator==(const Triangle& other) const;
+        inline bool operator!=(const Triangle& other) const;
+    };
+
+
+
+    inline bool Triangle::operator==(const Triangle& other) const {
+        return a == other.a && b == other.b && c == other.c;
+    }
+
+    inline bool Triangle::operator!=(const Triangle& other) const {
+        return !operator==(other);
+    }
+}
+
+#endif // PINE_MATH_TRIANGLE_H

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -3,46 +3,53 @@
 
 namespace Pine
 {
-    template <typename T>
     struct Vector2D;
-
-    template <typename T>
     struct Vector3D;
 
 
 
-    template <typename T>
     struct Vector2D
     {
-        T x;
-        T y;
+        float x;
+        float y;
 
-        inline bool operator==(const Vector2D<T>& other) const {
-            return x == other.x && y == other.y;
-        }
 
-        inline bool operator!=(const Vector2D<T>& other) const {
-            return !operator==(other);
-        }
+        inline bool operator==(const Vector2D& other) const;
+        inline bool operator!=(const Vector2D& other) const;
     };
 
 
 
-    template <typename T>
+    inline bool Vector2D::operator==(const Vector2D& other) const {
+        return x == other.x && y == other.y;
+    }
+
+    inline bool Vector2D::operator!=(const Vector2D& other) const {
+        return !operator==(other);
+    }
+
+
+
     struct Vector3D
     {
-        T x;
-        T y;
-        T z;
+        float x;
+        float y;
+        float z;
 
-        inline bool operator==(const Vector3D<T>& other) const {
-            return x == other.x && y == other.y && z == other.z;
-        }
 
-        inline bool operator!=(const Vector3D<T>& other) const {
-            return !operator==(other);
-        }
+        inline bool operator==(const Vector3D& other) const;
+        inline bool operator!=(const Vector3D& other) const;
     };
+
+
+
+    inline bool Vector3D::operator==(const Vector3D& other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+
+    inline bool Vector3D::operator!=(const Vector3D& other) const {
+        return !operator==(other);
+    }
 }
 
 #endif // PINE_MATH_VECTOR_H

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -18,7 +18,7 @@ namespace Pine
 
     // vvv Vector2D vvv
 
-    
+
 
     struct Vector2D
     {
@@ -185,7 +185,7 @@ namespace Pine
     {
         x -= rhs.x;
         y -= rhs.y;
-        z += rhs.z;
+        z -= rhs.z;
         return *this;
     }
 
@@ -271,6 +271,7 @@ namespace Pine
 
         vector.x /= length;
         vector.y /= length;
+        vector.z /= length;
 
         return vector;
     }

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -31,6 +31,9 @@ namespace Pine
         float y;
 
 
+        inline Vector2D() {}
+        inline Vector2D(float x, float y) : x(x), y(y) {}
+
         inline bool operator==(const Vector2D& other) const;
         inline bool operator!=(const Vector2D& other) const;
 
@@ -145,6 +148,9 @@ namespace Pine
         float y;
         float z;
 
+
+        inline Vector3D() {}
+        inline Vector3D(float x, float y, float z) : x(x), y(y), z(z) {}
 
         inline bool operator==(const Vector3D& other) const;
         inline bool operator!=(const Vector3D& other) const;

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -11,8 +11,14 @@ namespace Pine
     struct Vector3D;
 
 
+    inline Vector2D normalize(Vector2D vector);
+    inline Vector3D normalize(Vector3D vector);
+
+
 
     // vvv Vector2D vvv
+
+    
 
     struct Vector2D
     {
@@ -123,7 +129,11 @@ namespace Pine
         return std::sqrt((x * x) + (y * y));
     }
 
+
+
     // vvv Vector3D vvv // ^^^ Vector2D ^^^
+
+
 
     struct Vector3D
     {
@@ -239,7 +249,35 @@ namespace Pine
         return std::sqrt((x * x) + (y * y) + (z * z));
     }
 
-    // ^^^ Vector3D ^^^
+
+
+    // vvv Free Functions vvv // ^^^ Vector3D ^^^
+
+
+
+    inline Vector2D normalize(Vector2D vector)
+    {
+        float length = vector.length();
+
+        vector.x /= length;
+        vector.y /= length;
+
+        return vector;
+    }
+
+    inline Vector3D normalize(Vector3D vector)
+    {
+        float length = vector.length();
+
+        vector.x /= length;
+        vector.y /= length;
+
+        return vector;
+    }
+
+
+
+    // ^^^ Free Functions ^^^
 }
 
 #endif // PINE_MATH_VECTOR_H

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -14,6 +14,11 @@ namespace Pine
     inline Vector2D normalize(Vector2D vector);
     inline Vector3D normalize(Vector3D vector);
 
+    inline float dot(Vector2D vec1, Vector2D vec2);
+    inline float dot(Vector3D vec1, Vector3D vec2);
+
+    inline Vector3D cross(Vector3D vec1, Vector3D vec2);
+
 
 
     // vvv Vector2D vvv
@@ -274,6 +279,29 @@ namespace Pine
         vector.z /= length;
 
         return vector;
+    }
+
+
+
+    inline float dot(Vector2D vec1, Vector2D vec2) {
+        return (vec1.x * vec2.x) + (vec1.y * vec2.y);
+    }
+    
+    inline float dot(Vector3D vec1, Vector3D vec2) {
+        return (vec1.x * vec2.x) + (vec1.y * vec2.y) + (vec1.z + vec2.z);
+    }
+    
+    
+
+    inline Vector3D cross(Vector3D vec1, Vector3D vec2)
+    {
+        Vector3D result;
+
+        result.x = (vec1.y * vec2.z) - (vec1.z * vec2.y);
+        result.y = (vec1.z * vec2.x) - (vec1.x * vec2.z);
+        result.z = (vec1.x * vec2.y) - (vec1.y * vec2.x);
+        
+        return result;
     }
 
 

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -1,6 +1,10 @@
 #ifndef PINE_MATH_VECTOR_H
 #define PINE_MATH_VECTOR_H
 
+#include <cmath>
+
+
+
 namespace Pine
 {
     struct Vector2D;
@@ -30,6 +34,9 @@ namespace Pine
         friend inline Vector2D operator*(float scalar, const Vector2D& vector);
         friend inline Vector2D operator/(const Vector2D& vector, float scalar);
         friend inline Vector2D operator/(float scalar, const Vector2D& vector);
+
+
+        inline float length() const;
     };
 
 
@@ -110,6 +117,12 @@ namespace Pine
         return operator/(vector, scalar);
     }
 
+
+
+    inline float Vector2D::length() const {
+        return std::sqrt((x * x) + (y * y));
+    }
+
     // vvv Vector3D vvv // ^^^ Vector2D ^^^
 
     struct Vector3D
@@ -133,6 +146,9 @@ namespace Pine
         friend inline Vector3D operator*(float scalar, const Vector3D& vector);
         friend inline Vector3D operator/(const Vector3D& vector, float scalar);
         friend inline Vector3D operator/(float scalar, const Vector3D& vector);
+
+
+        inline float length() const;
     };
 
 
@@ -215,6 +231,12 @@ namespace Pine
 
     inline Vector3D operator/(float scalar, const Vector3D& vector) {
         return operator/(vector, scalar);
+    }
+
+
+
+    inline float Vector3D::length() const {
+        return std::sqrt((x * x) + (y * y) + (z * z));
     }
 
     // ^^^ Vector3D ^^^

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -5,26 +5,27 @@
 
 #include <cmath>
 
-
-
 namespace Pine
 {
     struct Vector2D;
     struct Vector3D;
 
 
-    inline Vector2D normalize(Vector2D vector);
-    inline Vector3D normalize(Vector3D vector);
+    inline Vector2D normalize(Vector2D v);
+    inline Vector3D normalize(Vector3D v);
 
-    inline float dot(Vector2D vec1, Vector2D vec2);
-    inline float dot(Vector3D vec1, Vector3D vec2);
+    inline float dot(Vector2D v1, Vector2D v2);
+    inline float dot(Vector3D v1, Vector3D v2);
 
-    inline Vector3D cross(Vector3D vec1, Vector3D vec2);
+    inline Vector3D cross(Vector3D v1, Vector3D v2);
 
+    // Operators for getting the vector from p1 (rhs) to p2 (lhs)
     template <typename T1, typename T2>
     inline Vector2D operator-(const Point2D<T1>& lhs, const Point2D<T2>& rhs);
     template <typename T1, typename T2>
     inline Vector3D operator-(const Point3D<T1>& lhs, const Point3D<T2>& rhs);
+
+    // Operators for getting the point a vector is pointing to from another point
     template <typename T>
     inline Point2D<float> operator+(const Point2D<T>& lhs, const Vector2D& rhs);
     template <typename T>
@@ -34,11 +35,7 @@ namespace Pine
     template <typename T>
     inline Point3D<float> operator+(const Vector3D& lhs, const Point3D<T>& rhs);
 
-
-
     // vvv Vector2D vvv
-
-
 
     struct Vector2D
     {
@@ -59,9 +56,9 @@ namespace Pine
 
         friend inline Vector2D operator+(const Vector2D& lhs, const Vector2D& rhs);
         friend inline Vector2D operator-(const Vector2D& lhs, const Vector2D& rhs);
-        friend inline Vector2D operator*(const Vector2D& vector, float scalar);
-        friend inline Vector2D operator*(float scalar, const Vector2D& vector);
-        friend inline Vector2D operator/(const Vector2D& vector, float scalar);
+        friend inline Vector2D operator*(const Vector2D& v, float scalar);
+        friend inline Vector2D operator*(float scalar, const Vector2D& v);
+        friend inline Vector2D operator/(const Vector2D& v, float scalar);
 
         inline float length() const;
     };
@@ -75,7 +72,7 @@ namespace Pine
     inline bool Vector2D::operator!=(const Vector2D& other) const {
         return !operator==(other);
     }
-    
+
 
 
     inline Vector2D& Vector2D::operator+=(const Vector2D& rhs)
@@ -122,20 +119,20 @@ namespace Pine
         return result;
     }
 
-    inline Vector2D operator*(const Vector2D& vector, float scalar)
+    inline Vector2D operator*(const Vector2D& v, float scalar)
     {
-        Vector2D result = vector;
+        Vector2D result = v;
         result *= scalar;
         return result;
     }
 
-    inline Vector2D operator*(float scalar, const Vector2D& vector) {
-        return operator*(vector, scalar);
+    inline Vector2D operator*(float scalar, const Vector2D& v) {
+        return v * scalar;
     }
 
-    inline Vector2D operator/(const Vector2D& vector, float scalar)
+    inline Vector2D operator/(const Vector2D& v, float scalar)
     {
-        Vector2D result = vector;
+        Vector2D result = v;
         result /= scalar;
         return result;
     }
@@ -146,11 +143,7 @@ namespace Pine
         return std::sqrt((x * x) + (y * y));
     }
 
-
-
     // vvv Vector3D vvv // ^^^ Vector2D ^^^
-
-
 
     struct Vector3D
     {
@@ -172,9 +165,9 @@ namespace Pine
 
         friend inline Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs);
         friend inline Vector3D operator-(const Vector3D& lhs, const Vector3D& rhs);
-        friend inline Vector3D operator*(const Vector3D& vector, float scalar);
-        friend inline Vector3D operator*(float scalar, const Vector3D& vector);
-        friend inline Vector3D operator/(const Vector3D& vector, float scalar);
+        friend inline Vector3D operator*(const Vector3D& v, float scalar);
+        friend inline Vector3D operator*(float scalar, const Vector3D& v);
+        friend inline Vector3D operator/(const Vector3D& v, float scalar);
 
         inline float length() const;
     };
@@ -239,20 +232,20 @@ namespace Pine
         return result;
     }
 
-    inline Vector3D operator*(const Vector3D& vector, float scalar)
+    inline Vector3D operator*(const Vector3D& v, float scalar)
     {
-        Vector3D result = vector;
+        Vector3D result = v;
         result *= scalar;
         return result;
     }
 
-    inline Vector3D operator*(float scalar, const Vector3D& vector) {
-        return operator*(vector, scalar);
+    inline Vector3D operator*(float scalar, const Vector3D& v) {
+        return v * scalar;
     }
 
-    inline Vector3D operator/(const Vector3D& vector, float scalar)
+    inline Vector3D operator/(const Vector3D& v, float scalar)
     {
-        Vector3D result = vector;
+        Vector3D result = v;
         result /= scalar;
         return result;
     }
@@ -263,40 +256,34 @@ namespace Pine
         return std::sqrt((x * x) + (y * y) + (z * z));
     }
 
-
-
     // vvv Free Functions vvv // ^^^ Vector3D ^^^
 
-
-
-    inline Vector2D normalize(Vector2D vector) {
-        return vector / vector.length();
+    inline Vector2D normalize(Vector2D v) {
+        return v / v.length();
     }
 
-    inline Vector3D normalize(Vector3D vector) {
-        return vector / vector.length();
+    inline Vector3D normalize(Vector3D v) {
+        return v / v.length();
     }
 
 
 
-    inline float dot(Vector2D vec1, Vector2D vec2) {
-        return (vec1.x * vec2.x) + (vec1.y * vec2.y);
+    inline float dot(Vector2D v1, Vector2D v2) {
+        return (v1.x * v2.x) + (v1.y * v2.y);
     }
-    
-    inline float dot(Vector3D vec1, Vector3D vec2) {
-        return (vec1.x * vec2.x) + (vec1.y * vec2.y) + (vec1.z + vec2.z);
+
+    inline float dot(Vector3D v1, Vector3D v2) {
+        return (v1.x * v2.x) + (v1.y * v2.y) + (v1.z * v2.z);
     }
-    
 
 
-    inline Vector3D cross(Vector3D vec1, Vector3D vec2)
+
+    inline Vector3D cross(Vector3D v1, Vector3D v2)
     {
         Vector3D result;
-
-        result.x = (vec1.y * vec2.z) - (vec1.z * vec2.y);
-        result.y = (vec1.z * vec2.x) - (vec1.x * vec2.z);
-        result.z = (vec1.x * vec2.y) - (vec1.y * vec2.x);
-        
+        result.x = (v1.y * v2.z) - (v1.z * v2.y);
+        result.y = (v1.z * v2.x) - (v1.x * v2.z);
+        result.z = (v1.x * v2.y) - (v1.y * v2.x);
         return result;
     }
 
@@ -306,10 +293,8 @@ namespace Pine
     inline Vector2D operator-(const Point2D<T1>& lhs, const Point2D<T2>& rhs)
     {
         Vector2D result;
-
         result.x = lhs.x - rhs.x;
         result.y = lhs.y - rhs.y;
-
         return result;
     }
 
@@ -317,39 +302,35 @@ namespace Pine
     inline Vector3D operator-(const Point3D<T1>& lhs, const Point3D<T2>& rhs)
     {
         Vector3D result;
-
         result.x = lhs.x - rhs.x;
         result.y = lhs.y - rhs.y;
         result.z = lhs.z - rhs.z;
-
         return result;
     }
-    
+
+
+
     template <typename T>
     inline Point2D<float> operator+(const Point2D<T>& lhs, const Vector2D& rhs)
     {
         Point2D<float> result;
-
         result.x = lhs.x + rhs.x;
         result.y = lhs.y + rhs.y;
-
         return result;
     }
-    
+
     template <typename T>
     inline Point2D<float> operator+(const Vector2D& lhs, const Point2D<T>& rhs) {
         return rhs + lhs;
     }
-    
+
     template <typename T>
     inline Point3D<float> operator+(const Point3D<T>& lhs, const Vector3D& rhs)
     {
         Point3D<float> result;
-
         result.x = lhs.x + rhs.x;
         result.y = lhs.y + rhs.y;
         result.z = lhs.z + rhs.z;
-
         return result;
     }
 
@@ -357,10 +338,6 @@ namespace Pine
     inline Point3D<float> operator+(const Vector3D& lhs, const Point3D<T>& rhs) {
         return rhs + lhs;
     }
-
-
-
-    // ^^^ Free Functions ^^^
 }
 
 #endif // PINE_MATH_VECTOR_H

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -1,6 +1,8 @@
 #ifndef PINE_MATH_VECTOR_H
 #define PINE_MATH_VECTOR_H
 
+#include "point.h"
+
 #include <cmath>
 
 
@@ -18,6 +20,19 @@ namespace Pine
     inline float dot(Vector3D vec1, Vector3D vec2);
 
     inline Vector3D cross(Vector3D vec1, Vector3D vec2);
+
+    template <typename T1, typename T2>
+    inline Vector2D operator-(const Point2D<T1>& lhs, const Point2D<T2>& rhs);
+    template <typename T1, typename T2>
+    inline Vector3D operator-(const Point3D<T1>& lhs, const Point3D<T2>& rhs);
+    template <typename T>
+    inline Point2D<float> operator+(const Point2D<T>& lhs, const Vector2D& rhs);
+    template <typename T>
+    inline Point2D<float> operator+(const Vector2D& lhs, const Point2D<T>& rhs);
+    template <typename T>
+    inline Point3D<float> operator+(const Point3D<T>& lhs, const Vector3D& rhs);
+    template <typename T>
+    inline Point3D<float> operator+(const Vector3D& lhs, const Point3D<T>& rhs);
 
 
 
@@ -296,6 +311,64 @@ namespace Pine
         result.z = (vec1.x * vec2.y) - (vec1.y * vec2.x);
         
         return result;
+    }
+
+
+
+    template <typename T1, typename T2>
+    inline Vector2D operator-(const Point2D<T1>& lhs, const Point2D<T2>& rhs)
+    {
+        Vector2D result;
+
+        result.x = lhs.x - rhs.x;
+        result.y = lhs.y - rhs.y;
+
+        return result;
+    }
+
+    template <typename T1, typename T2>
+    inline Vector3D operator-(const Point3D<T1>& lhs, const Point3D<T2>& rhs)
+    {
+        Vector3D result;
+
+        result.x = lhs.x - rhs.x;
+        result.y = lhs.y - rhs.y;
+        result.z = lhs.z - rhs.z;
+
+        return result;
+    }
+    
+    template <typename T>
+    inline Point2D<float> operator+(const Point2D<T>& lhs, const Vector2D& rhs)
+    {
+        Point2D<float> result;
+
+        result.x = lhs.x + rhs.x;
+        result.y = lhs.y + rhs.y;
+
+        return result;
+    }
+    
+    template <typename T>
+    inline Point2D<float> operator+(const Vector2D& lhs, const Point2D<T>& rhs) {
+        return rhs + lhs;
+    }
+    
+    template <typename T>
+    inline Point3D<float> operator+(const Point3D<T>& lhs, const Vector3D& rhs)
+    {
+        Point3D<float> result;
+
+        result.x = lhs.x + rhs.x;
+        result.y = lhs.y + rhs.y;
+        result.z = lhs.z + rhs.z;
+
+        return result;
+    }
+
+    template <typename T>
+    inline Point3D<float> operator+(const Vector3D& lhs, const Point3D<T>& rhs) {
+        return rhs + lhs;
     }
 
 

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -269,25 +269,12 @@ namespace Pine
 
 
 
-    inline Vector2D normalize(Vector2D vector)
-    {
-        float length = vector.length();
-
-        vector.x /= length;
-        vector.y /= length;
-
-        return vector;
+    inline Vector2D normalize(Vector2D vector) {
+        return vector / vector.length();
     }
 
-    inline Vector3D normalize(Vector3D vector)
-    {
-        float length = vector.length();
-
-        vector.x /= length;
-        vector.y /= length;
-        vector.z /= length;
-
-        return vector;
+    inline Vector3D normalize(Vector3D vector) {
+        return vector / vector.length();
     }
 
 

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -8,6 +8,8 @@ namespace Pine
 
 
 
+    // vvv Vector2D vvv
+
     struct Vector2D
     {
         float x;
@@ -16,6 +18,18 @@ namespace Pine
 
         inline bool operator==(const Vector2D& other) const;
         inline bool operator!=(const Vector2D& other) const;
+
+        inline Vector2D& operator+=(const Vector2D& rhs);
+        inline Vector2D& operator-=(const Vector2D& rhs);
+        inline Vector2D& operator*=(float scalar);
+        inline Vector2D& operator/=(float scalar);
+
+        friend inline Vector2D operator+(const Vector2D& lhs, const Vector2D& rhs);
+        friend inline Vector2D operator-(const Vector2D& lhs, const Vector2D& rhs);
+        friend inline Vector2D operator*(const Vector2D& vector, float scalar);
+        friend inline Vector2D operator*(float scalar, const Vector2D& vector);
+        friend inline Vector2D operator/(const Vector2D& vector, float scalar);
+        friend inline Vector2D operator/(float scalar, const Vector2D& vector);
     };
 
 
@@ -27,8 +41,76 @@ namespace Pine
     inline bool Vector2D::operator!=(const Vector2D& other) const {
         return !operator==(other);
     }
+    
 
 
+    inline Vector2D& Vector2D::operator+=(const Vector2D& rhs)
+    {
+        x += rhs.x;
+        y += rhs.y;
+        return *this;
+    }
+
+    inline Vector2D& Vector2D::operator-=(const Vector2D& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        return *this;
+    }
+
+    inline Vector2D& Vector2D::operator*=(float scalar)
+    {
+        x *= scalar;
+        y *= scalar;
+        return *this;
+    }
+
+    inline Vector2D& Vector2D::operator/=(float scalar)
+    {
+        x /= scalar;
+        y /= scalar;
+        return *this;
+    }
+
+
+
+    inline Vector2D operator+(const Vector2D& lhs, const Vector2D& rhs)
+    {
+        Vector2D result = lhs;
+        result += rhs;
+        return result;
+    }
+
+    inline Vector2D operator-(const Vector2D& lhs, const Vector2D& rhs)
+    {
+        Vector2D result = lhs;
+        result -= rhs;
+        return result;
+    }
+
+    inline Vector2D operator*(const Vector2D& vector, float scalar)
+    {
+        Vector2D result = vector;
+        result *= scalar;
+        return result;
+    }
+
+    inline Vector2D operator*(float scalar, const Vector2D& vector) {
+        return operator*(vector, scalar);
+    }
+
+    inline Vector2D operator/(const Vector2D& vector, float scalar)
+    {
+        Vector2D result = vector;
+        result /= scalar;
+        return result;
+    }
+
+    inline Vector2D operator/(float scalar, const Vector2D& vector) {
+        return operator/(vector, scalar);
+    }
+
+    // vvv Vector3D vvv // ^^^ Vector2D ^^^
 
     struct Vector3D
     {
@@ -39,6 +121,18 @@ namespace Pine
 
         inline bool operator==(const Vector3D& other) const;
         inline bool operator!=(const Vector3D& other) const;
+
+        inline Vector3D& operator+=(const Vector3D& rhs);
+        inline Vector3D& operator-=(const Vector3D& rhs);
+        inline Vector3D& operator*=(float scalar);
+        inline Vector3D& operator/=(float scalar);
+
+        friend inline Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs);
+        friend inline Vector3D operator-(const Vector3D& lhs, const Vector3D& rhs);
+        friend inline Vector3D operator*(const Vector3D& vector, float scalar);
+        friend inline Vector3D operator*(float scalar, const Vector3D& vector);
+        friend inline Vector3D operator/(const Vector3D& vector, float scalar);
+        friend inline Vector3D operator/(float scalar, const Vector3D& vector);
     };
 
 
@@ -50,6 +144,80 @@ namespace Pine
     inline bool Vector3D::operator!=(const Vector3D& other) const {
         return !operator==(other);
     }
+
+
+
+    inline Vector3D& Vector3D::operator+=(const Vector3D& rhs)
+    {
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        return *this;
+    }
+
+    inline Vector3D& Vector3D::operator-=(const Vector3D& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        z += rhs.z;
+        return *this;
+    }
+
+    inline Vector3D& Vector3D::operator*=(float scalar)
+    {
+        x *= scalar;
+        y *= scalar;
+        z *= scalar;
+        return *this;
+    }
+
+    inline Vector3D& Vector3D::operator/=(float scalar)
+    {
+        x /= scalar;
+        y /= scalar;
+        z /= scalar;
+        return *this;
+    }
+
+
+
+    inline Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs)
+    {
+        Vector3D result = lhs;
+        result += rhs;
+        return result;
+    }
+
+    inline Vector3D operator-(const Vector3D& lhs, const Vector3D& rhs)
+    {
+        Vector3D result = lhs;
+        result -= rhs;
+        return result;
+    }
+
+    inline Vector3D operator*(const Vector3D& vector, float scalar)
+    {
+        Vector3D result = vector;
+        result *= scalar;
+        return result;
+    }
+
+    inline Vector3D operator*(float scalar, const Vector3D& vector) {
+        return operator*(vector, scalar);
+    }
+
+    inline Vector3D operator/(const Vector3D& vector, float scalar)
+    {
+        Vector3D result = vector;
+        result /= scalar;
+        return result;
+    }
+
+    inline Vector3D operator/(float scalar, const Vector3D& vector) {
+        return operator/(vector, scalar);
+    }
+
+    // ^^^ Vector3D ^^^
 }
 
 #endif // PINE_MATH_VECTOR_H

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -46,7 +46,6 @@ namespace Pine
         friend inline Vector2D operator/(const Vector2D& vector, float scalar);
         friend inline Vector2D operator/(float scalar, const Vector2D& vector);
 
-
         inline float length() const;
     };
 
@@ -161,7 +160,6 @@ namespace Pine
         friend inline Vector3D operator*(float scalar, const Vector3D& vector);
         friend inline Vector3D operator/(const Vector3D& vector, float scalar);
         friend inline Vector3D operator/(float scalar, const Vector3D& vector);
-
 
         inline float length() const;
     };
@@ -291,7 +289,7 @@ namespace Pine
         return (vec1.x * vec2.x) + (vec1.y * vec2.y) + (vec1.z + vec2.z);
     }
     
-    
+
 
     inline Vector3D cross(Vector3D vec1, Vector3D vec2)
     {

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -47,7 +47,6 @@ namespace Pine
         friend inline Vector2D operator*(const Vector2D& vector, float scalar);
         friend inline Vector2D operator*(float scalar, const Vector2D& vector);
         friend inline Vector2D operator/(const Vector2D& vector, float scalar);
-        friend inline Vector2D operator/(float scalar, const Vector2D& vector);
 
         inline float length() const;
     };
@@ -126,10 +125,6 @@ namespace Pine
         return result;
     }
 
-    inline Vector2D operator/(float scalar, const Vector2D& vector) {
-        return operator/(vector, scalar);
-    }
-
 
 
     inline float Vector2D::length() const {
@@ -165,7 +160,6 @@ namespace Pine
         friend inline Vector3D operator*(const Vector3D& vector, float scalar);
         friend inline Vector3D operator*(float scalar, const Vector3D& vector);
         friend inline Vector3D operator/(const Vector3D& vector, float scalar);
-        friend inline Vector3D operator/(float scalar, const Vector3D& vector);
 
         inline float length() const;
     };
@@ -246,10 +240,6 @@ namespace Pine
         Vector3D result = vector;
         result /= scalar;
         return result;
-    }
-
-    inline Vector3D operator/(float scalar, const Vector3D& vector) {
-        return operator/(vector, scalar);
     }
 
 


### PR DESCRIPTION
Vector changes
- Removed template types from Vector2D and Vector3D. Both are now strictly floats.
- Added constructors.
- Added operator overloads and named functions for performing math operations on vectors, including dot and cross products, getting vectors from points, getting a point from a vector and another point, and normalizing vectors.
- Added member functions for getting the length of vectors.

Point changes
- Added constructors.
- Added functions for getting the distance between 2 points.
- Added explicit type casting operators. Opted to use templates to support all point type conversions.

Added math/math_common.h
- A new math header for generic and simple math. Currently has a template function for squaring integers since specific functions for this don't exist in the C++ standard library, with the closest being std::pow() and std::exp() which also have limitations on the supported types.

Added math/triangle.h
- A new math header with a struct for representing and storing triangles as a collection of 3 Point2D<float> types.

Added math/array.h
- A new math header for custom array types. Currently only intended for the 2D array type called Array2D, which represents a 2D array of data by reinterpreting an underlying std::vector.

math.h changes
- Added math/array.h.
- Added math/triangle.h.

Terminal changes
- Had to remove Terminal::moveCursor()'s Vector2D<int> overload since vectors strictly use floats now. The related overload for taking an x and y amount now performs the same behavior instead.